### PR TITLE
fix: Claude Code GitHub Actions OAuth認証エラーの修正

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,3 +30,4 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Claude Code GitHub ActionsでOAuth token使用時の401 Unauthorizedエラーを修正
- `github_token: ${{ secrets.GITHUB_TOKEN }}`パラメータを追加

## 問題

OAuth tokenのみではGitHub API操作（PR作成、issue操作等）に必要な認証が不足し、以下エラーが発生：
```
App token exchange failed: 401 Unauthorized - Claude Code is not installed on this repository
```

## 解決策

`claude_code_oauth_token`と`github_token`を併用することで：
- OAuth token: Claude APIアクセス用
- GitHub token: GitHub API操作用

## Test plan

- [ ] GitHub Actionsが正常に実行されることを確認
- [ ] @claudeメンション時にエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)